### PR TITLE
Managing Redis Backed AWS ElastiCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ Set environment variables prefixed with `TF_VAR_`. e.g.
 export TF_VAR_private_key="~/Downloads/keylimepie.pem"
 export TF_VAR_key_name="keylimepie"
 export TF_VAR_bastion_ip="35.171.26.242"
+export TF_VAR_redis_cluster_id="myrediscluster"
+export TF_VAR_redis_tag_name="myredistag"
+export TF_VAR_redis_tag_environment="myredisenv"
+
+

--- a/env-staging/staging.tf
+++ b/env-staging/staging.tf
@@ -26,6 +26,31 @@ variable "kafka_environment" {
     default     = "staging_default"
 }
 
+variable "redis_tag_name" {
+  type        = "string"
+  description = "Tag name for the Redis cluster"
+  default     = "stg-redis"
+}
+
+variable "redis_tag_environment" {
+  type        = "string"
+  description = "Tag environment for the Redis cluster"
+  default     = "stg-env"
+}
+
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-parameter-group.html
+variable "redis_parameter_group_name" {
+  type        = "string"
+  description = "Parameter Group for ElastiCache"
+  default     = "stg-prm-gp"
+}
+
+variable "redis_cluster_id" {
+  type        = "string"
+  description = "Redis cluster identifier"
+  default     = "stg-cluster"
+}
+
 module "kafka" {
     source = "../modules/kafka"
     
@@ -51,4 +76,14 @@ module "nrc" {
 
     // TODO: replace following with list of brokers when NRC is ready to accept it
     kafka_brokers = "${module.kafka.first_kafka_broker}"
+}
+
+module "redis" {
+  
+  source = "../modules/redis"
+  
+  redis_cluster_id = "${var.redis_cluster_id}"
+  redis_tag_environment = "${var.redis_tag_environment}"
+  redis_tag_name = "${var.redis_tag_name}"
+  redis_parameter_group_name = "${var.redis_parameter_group_name}"  
 }

--- a/modules/redis/cache.tf
+++ b/modules/redis/cache.tf
@@ -1,0 +1,15 @@
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "${var.redis_cluster_id}"
+  engine               = "redis"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = "1"
+  parameter_group_name = "default.redis3.2"
+  port                 = "6379"
+  subnet_group_name    = "redis-subnet-group"
+  security_group_ids   = ["${data.aws_security_group.redis.id}"]
+
+  tags {
+    Name          = "${var.redis_tag_name}"
+    environment   = "${var.redis_tag_environment}"
+  }
+}

--- a/modules/redis/data.tf
+++ b/modules/redis/data.tf
@@ -1,0 +1,3 @@
+data "aws_security_group" "redis" {
+  id = "sg-7789513e"
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,0 +1,20 @@
+variable "redis_tag_name" {
+  type        = "string"
+  description = "Tag name for the Redis cluster"
+}
+
+variable "redis_tag_environment" {
+  type        = "string"
+  description = "Tag environment for the Redis cluster"
+}
+
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-parameter-group.html
+variable "redis_parameter_group_name" {
+  type        = "string"
+  description = "Parameter Group for ElastiCache"
+}
+
+variable "redis_cluster_id" {
+  type        = "string"
+  description = "Redis cluster identifier"
+}


### PR DESCRIPTION
Bring up a `cache.t2.micro` Redis backed ElastiCache cluster for NRC staging pipeline.